### PR TITLE
Added checks if models and tr is nil.

### DIFF
--- a/astrea-toolbox-tools/lua/weapons/gmod_tool/stools/astrea_model_blacklister.lua
+++ b/astrea-toolbox-tools/lua/weapons/gmod_tool/stools/astrea_model_blacklister.lua
@@ -19,14 +19,18 @@ end
 
 -- Left click adds the model you are looking at to the blacklist
 function TOOL:LeftClick( trace )
+	if not tr then return end 
+	
+	local ent = trace.Entity
+	if ( !IsValid( ent ) ) then return false end 
+	
 	local ply = self:GetOwner()
 	if not AstreaToolbox.Config.DefaultAdmins.UserGroups[ply:GetUserGroup()] and not AstreaToolbox.Config.DefaultAdmins.Players[ply:SteamID64()] then return end
 
-	local ent = trace.Entity
-	if ( !IsValid( ent ) ) then return false end -- The entity is valid and isn't worldspawn
-
 	local model = ent:GetModel()
-	if (AstreaToolbox.Core.GetSetting("prop_blacklist_list")[model]) then
+	local models = AstreaToolbox.Core.GetSetting("prop_blacklist_list")
+	
+	if (models and models[model]) then
 		ent:Remove()
 	else
 		AstreaToolbox.Core.AddToList("prop_blacklist_list", model)
@@ -39,11 +43,13 @@ end
 
 -- right click removes the model you are looking at to the blacklist
 function TOOL:RightClick( trace )
+	if not tr then return end 
+	
+	local ent = trace.Entity
+	if ( !IsValid( ent ) ) then return false end
+	
 	local ply = self:GetOwner()
 	if not AstreaToolbox.Config.DefaultAdmins.UserGroups[ply:GetUserGroup()] and not AstreaToolbox.Config.DefaultAdmins.Players[ply:SteamID64()] then return end
-
-	local ent = trace.Entity
-	if ( !IsValid( ent ) ) then return false end -- The entity is valid and isn't worldspawn
 
 	local model = ent:GetModel()
 	AstreaToolbox.Core.RemoveFromList("prop_blacklist_list", model, 65535)
@@ -54,21 +60,25 @@ function TOOL:RightClick( trace )
 end
 
 function TOOL:Reload(trace)
+	if not tr then return end 
+	
+	local ent = trace.Entity
+	if ( !IsValid( ent ) ) then return false end 
+	
 	local ply = self:GetOwner()
 	if not AstreaToolbox.Config.DefaultAdmins.UserGroups[ply:GetUserGroup()] and not AstreaToolbox.Config.DefaultAdmins.Players[ply:SteamID64()] then return end
 
-	local ent = trace.Entity
-	if ( !IsValid( ent ) ) then return false end -- The entity is valid and isn't worldspawn
-
-	local model = string.lower(ent:GetModel())
+    local model = string.lower(ent:GetModel())
     local models = AstreaToolbox.Core.GetSetting("prop_blacklist_list")
 
+    if not models then return end
+	
     if models[model] then 
         --AstreaToolbox.Core.Message(ply, "This model is in the blacklist", AstreaToolbox.Core.Translated("props_prefix"))
-		AstreaToolbox.Core.Notify(ply, "This model is in the blacklist", 0, 2)
+	AstreaToolbox.Core.Notify(ply, "This model is in the blacklist", 0, 2)
     else
     	--AstreaToolbox.Core.Message(ply, "This model is not in the blacklist", AstreaToolbox.Core.Translated("props_prefix"))
-		AstreaToolbox.Core.Notify(ply, "This model is not in the blacklist", 1, 2)
+	AstreaToolbox.Core.Notify(ply, "This model is not in the blacklist", 1, 2)
     end 
 	
 	return true


### PR DESCRIPTION
AstreaToolbox.Core.GetSetting("prop_blacklist_list") can return false if there are no items in the list, so I've added a check for that.

Now checking if the entity is valid before checking the player's validity as if the entity isn't valid we might as well not bother with the player.

Note: Indenting needs prettying up, but can't do that nicely from git. xoxo